### PR TITLE
Add eID framework to Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,14 +7,11 @@ let package = Package(
     name: "IDnowSDK",
     platforms: [.iOS(.v11)],
     products: [
-        .library(
-            name: "IDnowSDK",
-            targets: ["IDnowSDK"]),
+        .library(name: "IDnowSDK", targets: ["IDnowVideo"]),
+        .library(name: "IDnowSDK-with-NFC", targets: ["IDnowVideo", "IDnowEID"]),
     ],
     targets: [
-        .binaryTarget(
-                            name: "IDnowSDK",
-                            path: "idnow_vi.xcframework"
-                    )
+        .binaryTarget(name: "IDnowVideo", path: "idnow_vi.xcframework"),
+        .binaryTarget(name: "IDnowEID", path: "eid/idnow_eid.xcframework"),
     ]
 )


### PR DESCRIPTION
I tried to use similar naming as IDNowSDKCore auto ident package.

It's unclear to me the technical difficulties behind not making `AuthadaAuthenticationLibrary.xcframework` available too but at least we could have the eID framework available.